### PR TITLE
Fix "checkpoint" json key name in validation reports. Should be check_point.

### DIFF
--- a/mobi.chouette.exchange/src/main/java/mobi/chouette/exchange/report/FileReport.java
+++ b/mobi.chouette.exchange/src/main/java/mobi/chouette/exchange/report/FileReport.java
@@ -14,7 +14,6 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import mobi.chouette.exchange.report.ActionReporter.FILE_STATE;
 import mobi.chouette.exchange.validation.report.CheckPointReport.SEVERITY;
-
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -40,16 +39,16 @@ public class FileReport extends AbstractReport{
 	private List<FileError> errors = new ArrayList<>();
 	
 	
-	@XmlElement(name = "checkpoint_errors")
+	@XmlElement(name = "check_point_errors")
 	private List<Integer> checkPointErrorKeys = new ArrayList<Integer>();
 	
-	@XmlElement(name = "checkpoint_warnings")
+	@XmlElement(name = "check_point_warnings")
 	private List<Integer> checkPointWarningKeys = new ArrayList<Integer>();
 
-	@XmlElement(name = "checkpoint_error_count")
+	@XmlElement(name = "check_point_error_count")
 	private int checkPointErrorCount = 0;
 
-	@XmlElement(name = "checkpoint_warning_count")
+	@XmlElement(name = "check_point_warning_count")
 	private int checkPointWarningCount = 0;
 
 	protected void addError(FileError fileError2) {

--- a/mobi.chouette.exchange/src/main/java/mobi/chouette/exchange/report/ObjectReport.java
+++ b/mobi.chouette.exchange/src/main/java/mobi/chouette/exchange/report/ObjectReport.java
@@ -15,7 +15,6 @@ import lombok.ToString;
 import mobi.chouette.exchange.report.ActionReporter.OBJECT_STATE;
 import mobi.chouette.exchange.report.ActionReporter.OBJECT_TYPE;
 import mobi.chouette.exchange.validation.report.CheckPointReport.SEVERITY;
-
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -48,19 +47,19 @@ public class ObjectReport extends AbstractReport {
 	@Getter
 	private List<ObjectError> errors = new ArrayList<ObjectError>();
 
-	@XmlElement(name = "checkpoint_errors")
+	@XmlElement(name = "check_point_errors")
 	@Getter
 	private List<Integer> checkPointErrorKeys = new ArrayList<Integer>();
 	
-	@XmlElement(name = "checkpoint_warnings")
+	@XmlElement(name = "check_point_warnings")
 	@Getter
 	private List<Integer> checkPointWarningKeys = new ArrayList<Integer>();
 
-	@XmlElement(name = "checkpoint_error_count")
+	@XmlElement(name = "check_point_error_count")
 	@Getter
 	private int checkPointErrorCount = 0;
 
-	@XmlElement(name = "checkpoint_warning_count")
+	@XmlElement(name = "check_point_warning_count")
 	@Getter
 	private int checkPointWarningCount = 0;
 


### PR DESCRIPTION
Fix "checkpoint" json key name in validation reports. Should be check_point.